### PR TITLE
Prevent anchor titles to be overlapped by the fixed navbar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -21,6 +21,14 @@ h1,h2,h3,h4,h5,h6 {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 800;
 }
+h1::before,h2::before,h3::before,h4::before,h5::before,h6::before {
+  /* Hash Tag Links That Don't Headbutt The Browser Window */
+  display: block;
+  content: "";
+  height: 70px;
+  margin-top: -70px;
+  visibility: hidden;
+}
 a {
   color: #008AFF;
 }
@@ -186,14 +194,14 @@ img {
     width: 100px;
     margin-top: -50px;
   }
-  
+
   .navbar-custom .avatar-container  .avatar-img-border {
     width: 100%;
     box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
     -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
     -moz-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
   }
-  
+
   .navbar-custom .avatar-container  .avatar-img {
     width: 100%;
   }
@@ -285,7 +293,7 @@ footer .theme-by {
     font-size: 16px;
   }
 }
- 
+
 /* --- Post preview --- */
 
 .post-preview {
@@ -430,11 +438,11 @@ footer .theme-by {
   }
   .intro-header.big-img {
     margin-top: 91px;  /* Full navbar is small navbar + 20px padding on each side when expanded */
-  }	
+  }
   .intro-header.big-img .page-heading,
   .intro-header.big-img .post-heading  {
     padding: 150px 0;
-  }  
+  }
   .intro-header .page-heading h1 {
     font-size: 80px;
   }
@@ -471,9 +479,9 @@ footer .theme-by {
   }
   .header-section.has-img .big-img {
     margin-bottom: 0;
-  }  
-} 
-@media only screen and (max-width: 325px) { 
+  }
+}
+@media only screen and (max-width: 325px) {
   .intro-header.big-img {
     height: 200px;
   }


### PR DESCRIPTION
Clicking on the index links move the page to the right place, but because there is a fixed header overlapping the titles, the context is not immediate and the user might feel lost.

Following [this technique](https://css-tricks.com/hash-tag-links-padding/), all titles now are still visible.

Sorry about the extra lines on the diff, my editor removes whitespace on save… I can revert them, if you want. :)
