### PR TITLE
Add hanami-cli library to CLI list

### DIFF
--- a/_posts/1970-01-01-cli.md
+++ b/_posts/1970-01-01-cli.md
@@ -12,3 +12,4 @@ Also, we need to understand that there are much cleaner alternatives, like Thor.
 
 * [Rake](http://docs.seattlerb.org/rake/)
 * [Thor](https://github.com/erikhuda/thor)
+* [hanami-cli](https://github.com/hanami/cli)


### PR DESCRIPTION
Hey again. We maid hanami cli with zero dependencies. It's mean that you can use it in any projects