### PR TITLE
Drop Scientist library from benchmark list

### DIFF
--- a/_posts/1970-01-01-performance.md
+++ b/_posts/1970-01-01-performance.md
@@ -22,4 +22,3 @@ TODO: Add gems that help to track N+1 queries and SQL performance
 Sometimes, in the development stage, you need to measure the performance of a couple of different implementations. To get measurable timing results, the code being benchmarked should be run repeatedly, for many iterations. There are ready-made tools that can help with such measurements.
 
 * [Benchmark ips](https://github.com/evanphx/benchmark-ips)
-* [Scientist](https://github.com/github/scientist)


### PR DESCRIPTION
[scientist](https://github.com/github/scientist/) library was created for safe refactoring parts of ruby code. It compares a result of old code and a result of new code, after calling some callbacks (like something wrong and something is okay). After that scientist returns old code result.

In this case, using scientist as a benchmark library is a strange idea. You can do it, but it's not a general case for it. That's why I think can drop it from